### PR TITLE
Remove sdx-oxp-integrator from CI report due to inactive maintenance

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -18,7 +18,6 @@ is on these repositories:
 | [datamodel][datamodel]             | [![datamodel-ci-badge]][datamodel-ci]    | [![datamodel-cov-badge]][datamodel-cov]   |
 | [pce][pce]                         | [![pce-ci-badge]][pce-ci]                | [![pce-cov-badge]][pce-cov]               |
 | [kytos-sdx][topology]              | [![topology-ci-badge]][topology-ci]      | [![topology-cov-badge]][topology-cov]     |
-| [sdx-oxp-integrator][integrator]   | [![integrator-ci-badge]][integrator-ci]  | [![integrator-cov-badge]][integrator-cov] |
 
 Documentation is available at [sdx-docs.readthedocs.io][sdx-docs-rtd],
 and we're working on it at [sdx-docs][sdx-docs-github] repository.
@@ -97,14 +96,6 @@ about AtlanticWave-SDX, are listed in our website, along with some
 
 [topology-cov-badge]: https://coveralls.io/repos/github/atlanticwave-sdx/kytos-sdx/badge.svg?branch=main
 [topology-cov]: https://coveralls.io/github/atlanticwave-sdx/kytos-sdx?branch=main
-
-<!-- integrator URLs -->
-[integrator]: https://github.com/atlanticwave-sdx/sdx-oxp-integrator
-[integrator-ci-badge]: https://github.com/atlanticwave-sdx/sdx-oxp-integrator/actions/workflows/test.yml/badge.svg
-[integrator-ci]: https://github.com/atlanticwave-sdx/sdx-oxp-integrator/actions/workflows/test.yml
-
-[integrator-cov-badge]: https://coveralls.io/repos/github/atlanticwave-sdx/sdx-oxp-integrator/badge.svg?branch=main (Coverage Status)
-[integrator-cov]: https://coveralls.io/github/atlanticwave-sdx/sdx-oxp-integrator?branch=main
 
 <!-- sdx-continuous-development URLs -->
 [cd]: https://github.com/atlanticwave-sdx/sdx-continuous-development


### PR DESCRIPTION
kytos-sdx and sdx-oxp-integrator currently overlap in functionality: both convert Kytos topology data into the SDX/OXP topology model.

The key difference is architectural:

* sdx-oxp-integrator implements this logic as standalone Python code and does not depend on Kytos.
* kytos-sdx integrates the same functionality directly within the Kytos ecosystem.

At the moment, active development and updates are happening in kytos-sdx, which is why it is being highlighted and referenced instead of sdx-oxp-integrator.

That said, sdx-oxp-integrator remains valuable as an option if we later decide to:

* decouple topology conversion from Kytos, or
* Reuse the functionality in environments where Kytos is not present.

For now, this change is about reflecting the current focus and active code path, not deprecating or removing sdx-oxp-integrator.